### PR TITLE
Add Linux build shims for dxil converter

### DIFF
--- a/external/win_shim/com_fake.h
+++ b/external/win_shim/com_fake.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <stdint.h>
+typedef uint8_t  BYTE;  typedef uint16_t WORD;  typedef uint32_t DWORD;
+typedef int32_t  BOOL;  typedef int32_t HRESULT; typedef uint32_t UINT;
+typedef unsigned long long UINT64;
+typedef const char* LPCSTR;  typedef void* LPVOID; typedef uintptr_t SIZE_T;
+struct _GUID { uint32_t D1; uint16_t D2,D3; BYTE D4[8]; };
+typedef _GUID GUID, IID, CLSID;
+#ifndef interface
+#define interface struct
+#endif
+#define DEFINE_GUID(n,...) extern const GUID n
+#define DECLSPEC_UUID(x)
+#define DECLSPEC_NOVTABLE
+#define __stdcall
+#define STDMETHODCALLTYPE
+#define MIDL_INTERFACE(x) struct __attribute__((uuid(x)))
+#define EXTERN_C extern "C"
+#define RPC_IF_HANDLE void*
+#define UInt32Add(a,b,c) ((*(c)=uint32_t((a)+(b))),0)
+#define DEFINE_ENUM_FLAG_OPERATORS(TYPE)
+#ifndef __assume
+#define __assume(x) ((void)0)
+#endif

--- a/projects/CMakeLists.txt
+++ b/projects/CMakeLists.txt
@@ -1,11 +1,10 @@
 set(DXC_PROJECTS_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(DXC_PROJECTS_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
-if(WIN32)
-add_subdirectory(include/Tracing) # DxcRuntimeEtw target
+if (WIN32)
+  add_subdirectory(include/Tracing)
+endif() # DxcRuntimeEtw target
 
 if(HLSL_BUILD_DXILCONV)
   add_subdirectory(dxilconv)
 endif (HLSL_BUILD_DXILCONV)
-
-endif (WIN32)

--- a/projects/dxilconv/include/Support/DXIncludes.h
+++ b/projects/dxilconv/include/Support/DXIncludes.h
@@ -20,20 +20,15 @@
 #define NOMINMAX 1
 #define WIN32_LEAN_AND_MEAN 1
 #define VC_EXTRALEAN 1
-#include <windows.h>
-#include <strsafe.h>
+#include "external/win_shim/com_fake.h"
+#define COM_NO_WINDOWS_H
 
-#include <dxgitype.h>
-#include <d3dcommon.h>
-#include <d3d11.h>
 #include <d3d12.h>
 #include "dxc/Support/d3dx12.h"
 #include "DxbcSignatures.h"
-#include <d3dcompiler.h>
-#include <wincrypt.h>
 
 #ifndef DECODE_D3D10_SB_TOKENIZED_PROGRAM_TYPE
-#include "dxc\Support\d3d12TokenizedProgramFormat.hpp"
+#include "dxc/Support/d3d12TokenizedProgramFormat.hpp"
 #endif
 
 #include "ShaderBinary/ShaderBinary.h"

--- a/projects/dxilconv/lib/DxbcConverter/CMakeLists.txt
+++ b/projects/dxilconv/lib/DxbcConverter/CMakeLists.txt
@@ -12,7 +12,11 @@ target_link_libraries(DxbcConverter PUBLIC
   ShaderBinary
 )
 
-add_dependencies(DxbcConverter intrinsics_gen DxcRuntimeEtw DxilConvPasses)
+if (WIN32)
+  add_dependencies(DxbcConverter intrinsics_gen DxcRuntimeEtw DxilConvPasses)
+else()
+  add_dependencies(DxbcConverter intrinsics_gen DxilConvPasses)
+endif()
 
 target_include_directories(DxbcConverter
 PUBLIC

--- a/projects/dxilconv/lib/ShaderBinary/ShaderBinaryIncludes.h
+++ b/projects/dxilconv/lib/ShaderBinary/ShaderBinaryIncludes.h
@@ -10,8 +10,8 @@
 #pragma once
 // clang-format off
 // Includes on Windows are highly order dependent.
-#include "windows.h"
-
+#include "external/win_shim/com_fake.h"
+#define COM_NO_WINDOWS_H
 #include <assert.h>
 #include <float.h>
 #include <strsafe.h>

--- a/projects/include/Tracing/DxcRuntimeEtw.h
+++ b/projects/include/Tracing/DxcRuntimeEtw.h
@@ -1,0 +1,8 @@
+#pragma once
+#define DxcRuntimeEtw_DxcRuntimeInitialization_Start()
+#define DxcRuntimeEtw_DxcRuntimeInitialization_Stop(x)
+#define DxcRuntimeEtw_DxcRuntimeShutdown_Start()
+#define DxcRuntimeEtw_DxcRuntimeShutdown_Stop(x)
+#define DxcRuntimeEtw_DxcTranslate_Start()
+#define DxcRuntimeEtw_DxcTranslate_TranslateStats(...)
+#define DxcRuntimeEtw_DxcTranslate_Stop(x)


### PR DESCRIPTION
## Summary
- add minimal COM/Windows shim
- stub out ETW tracing and guard CMake dependencies
- adjust DXIL converter includes for cross-platform builds

## Testing
- `cmake ../DirectXShaderCompiler -G Ninja -DCMAKE_BUILD_TYPE=Release -DHLSL_BUILD_DXILCONV=ON -DHLSL_OPTIONAL_PROJS_IN_DEFAULT=OFF -DHLSL_INCLUDE_TESTS=OFF -DD3D12_INCLUDE_DIR=$DX_HEADERS -DXGI_INCLUDE_DIR=$DX_HEADERS -DD3D12_INCLUDE_DIRS=$DX_HEADERS` *(fails: invalid target to enable: 'AMDGPU')*


------
https://chatgpt.com/codex/tasks/task_e_6890e034152c832eb46db21f30c83779